### PR TITLE
Remove r-btach dependencies version numebering cleanin

### DIFF
--- a/tools/macros/macros.xml
+++ b/tools/macros/macros.xml
@@ -12,9 +12,8 @@
 
     <xml name="requirements">
         <requirements>
+		    <requirement type=”package” version=”4.2.1”>r-base</requirement>
             <requirement type="package" version="@TOOL_VERSION@">bioconductor-metams</requirement>
-            <requirement type="package" version="1.1_5">r-batch</requirement>
-            <yield />
         </requirements>
     </xml>
 

--- a/tools/metaMS_plot/metaMS_plot.r
+++ b/tools/metaMS_plot/metaMS_plot.r
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
-# metaMS_plot.r version="1.0.0"
+# metaMS_plot.r version="1.0.1"
 #created by Yann GUITTON and updated by Julien SAINT-VANNE
 
 
@@ -18,9 +18,24 @@ source_local <- function(fname) {
     base_dir <- dirname(substring(argv[grep("--file=", argv)], 8))
     source(paste(base_dir, fname, sep="/"))
 }
+
+#This function is made to replace r-batch package dependencie
+#@author L. Pavot
+parse_args <- function() {
+  args <- commandArgs()
+  start <- which(args == "--args")[1] + 1
+  if (is.na(start)) {
+	return(list())
+  }
+  seq_by2 <- seq(start, length(args), by = 2)
+  result <- as.list(args[seq_by2 + 1])
+  names(result) <- args[seq_by2]
+  return(result)
+}
+
 source_local("lib_metams.r")
 
-pkgs <- c("metaMS","batch") #"batch" necessary for parseCommandArgs function
+pkgs <- c("metaMS") #remove "batch" dependencies
 loadAndDisplayPackages(pkgs)
 
 cat("\n")
@@ -32,7 +47,7 @@ cat("\nStart of the '", modNamC, "' Galaxy module call: ", format(Sys.time(), "%
 
 # ----- ARGUMENTS -----
 cat("\tARGUMENTS INFO\n\n")
-args = parseCommandArgs(evaluate=FALSE) #interpretation of arguments given in command line as an R list of objects
+args <- parse_args() #interpretation of arguments given in command line as an R list of objects
 #write.table(as.matrix(args), col.names=F, quote=F, sep='\t\t')
 print(cbind(value = unlist(args)))
 

--- a/tools/metaMS_plot/metaMS_plot.xml
+++ b/tools/metaMS_plot/metaMS_plot.xml
@@ -1,4 +1,4 @@
- <tool id="metams_plot" name="metaMS.plot" version="@TOOL_VERSION@+galaxy0">
+ <tool id="metams_plot" name="metaMS.plot" version="1.0.1+@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
 
     <description>GC-MS data preprocessing using metaMS package</description>
 
@@ -231,6 +231,10 @@ Output files
 
 Changelog/News
 --------------
+**Version 1.0.1 - 22/09/2022**
+
+- Remove r-batch package dependencie
+
 **Version 1.0 - 20/05/2019**
 
 - NEW: new tool extract from previous metaMS_runGC tool

--- a/tools/metaMS_runGC/metaMS_runGC.r
+++ b/tools/metaMS_runGC/metaMS_runGC.r
@@ -1,8 +1,7 @@
 #!/usr/bin/env Rscript
-# metaMS_runGC.r version="3.0.0"
+# metaMS_runGC.r version="3.0.1"
 #created by Yann GUITTON and updated by Julien SAINT-VANNE
-#use RI options + add try on plotUnknown add session Info
-#use make.names in sampleMetadata to avoid issues with files names 
+#remove batch dependence
 
 
 # ----- LOG FILE -----
@@ -20,9 +19,24 @@ source_local <- function(fname) {
     base_dir <- dirname(substring(argv[grep("--file=", argv)], 8))
     source(paste(base_dir, fname, sep="/"))
 }
+
+#This function is made to replace r-batch package dependencie
+#@author L. Pavot
+parse_args <- function() {
+  args <- commandArgs()
+  start <- which(args == "--args")[1] + 1
+  if (is.na(start)) {
+	return(list())
+  }
+  seq_by2 <- seq(start, length(args), by = 2)
+  result <- as.list(args[seq_by2 + 1])
+  names(result) <- args[seq_by2]
+  return(result)
+}
+
 source_local("lib_metams.r")
 
-pkgs <- c("metaMS","stringr","batch","CAMERA") #"batch" necessary for parseCommandArgs function
+pkgs <- c("metaMS","stringr","CAMERA") # removed batch
 loadAndDisplayPackages(pkgs)
 
 cat("\n\n")
@@ -33,7 +47,7 @@ cat("\nStart of the '", modNamC, "' Galaxy module call: ", format(Sys.time(), "%
 
 # ----- PROCESSING INFILE -----
 cat("\n\n\tARGUMENTS PROCESSING INFO\n\n")
-args = parseCommandArgs(evaluate=FALSE) #interpretation of arguments given in command line as an R list of objects
+args <- parse_args() #interpretation of arguments given in command line as an R list of objects modified after r-batch removal
 #write.table(as.matrix(args), col.names=F, quote=F, sep='\t\t')
 print(cbind(value = unlist(args)))
 

--- a/tools/metaMS_runGC/metams_runGC.xml
+++ b/tools/metaMS_runGC/metams_runGC.xml
@@ -1,4 +1,4 @@
- <tool id="metams_runGC" name="metaMS.runGC" version="3.0.0+metaMS@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
+ <tool id="metams_runGC" name="metaMS.runGC" version="3.0.1+metaMS@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
 
     <description>GC-MS data preprocessing using metaMS package</description>
 
@@ -203,7 +203,7 @@ metaMS.runGC
 Description
 -----------
 metaMS.runGC is a function dedicated to GCMS data processing from converted files to the generation of pseudospectra (compounds) table.
-Current version for metaMS R package: 1.18.1
+Current version for metaMS R package: @TOOL_VERSION@
 
 **Process:** 
 Each of the converted data (cdf, mzML...)  is profiled by a combination of xcms and CAMERA functions. Then all the mass spectra of detected peaks are compared and clustered.
@@ -322,6 +322,9 @@ Output files
 
 Changelog/News
 --------------
+**Version 3.0.1 - 22/09/2022**
+
+- Remove r-batch package dependencie
 
 **Version 3.0 - 20/05/2019**
 

--- a/tools/scripts/lib_metams.r
+++ b/tools/scripts/lib_metams.r
@@ -1,7 +1,8 @@
-# lib_metams.r version 2.1.1
+# lib_metams.r version 2.1.2
 # R function for metaMS runGC under W4M
 # author Yann GUITTON CNRS IRISA/LINA Idealg project 2014-2015
-# author Yann GUITTON Oniris Laberca 2015-2017
+# author Yann GUITTON Oniris Laberca 2015-2021
+# author Yann GUITTON Oniris INRAE Laberca 2021-2022
 
 
 #@author G. Le Corguille


### PR DESCRIPTION
Hi,

Just a PR to not forget the batch removal during formation.

I didn't checked if it works yet !

Maybe be careful with the `@TOOL_VERSION@` because planemo may not accept it in the versioning